### PR TITLE
Support New Chrome and undetected-chromedriver Versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-selenium==4.8.3 
-undetected-chromedriver==3.4.6 
-webdriver-manager==  3.8.6 
+selenium==4.16.0
+undetected-chromedriver==3.5.4
+webdriver-manager==4.0.1 
 Pillow==10.0.1
 deepface
 opencv-python

--- a/tinderbotz/session.py
+++ b/tinderbotz/session.py
@@ -1,7 +1,7 @@
 # Selenium: automation of browser
 from selenium import webdriver
 # from webdriver_manager.chrome import ChromeDriverManager
-import undetected_chromedriver.v2 as uc
+import undetected_chromedriver as uc
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.common.by import By
@@ -47,6 +47,8 @@ class Session:
         }
 
         start_session = time.time()
+
+        self.started = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime())
 
         # this function will run when the session ends
         @atexit.register
@@ -122,8 +124,7 @@ class Session:
         # Cool banner
         print(Printouts.BANNER.value)
         time.sleep(1)
-
-        self.started = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime())
+        
         print("Started session: {}\n\n".format(self.started))
 
     # Setting a custom location


### PR DESCRIPTION
This is to address issues #123 and #126.

- Bumped selenium (4.16.0), undetected-chromedriver (3.5.4), and webdriver-manager (4.0.1) to support the newest Chrome versions (114 and above).

- Removed ".v2" from "import undetected_chromedriver.v2" to address new version importing issue.

- Moved self.started attribute declaration to line 51 so that line 71 doesn't raise "no attribute 'started'" exception.

Tested with Chrome v120 and confirmed everything runs smoothly.
